### PR TITLE
Screen Rotation locked To portrait

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         <activity
             android:name=".MainActivity"
             android:label="Blastar"
+            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Rotating the device caused the activity to reload due to which the game starts from the beginning.